### PR TITLE
Important fix

### DIFF
--- a/tools/captain/run.sh
+++ b/tools/captain/run.sh
@@ -26,7 +26,7 @@ fi
 MAGMA=${MAGMA:-"$(cd "$(dirname "${BASH_SOURCE[0]}")/../../" >/dev/null 2>&1 \
     && pwd)"}
 export MAGMA
-WORKERS=${WORKERS:-(( $(nproc) - 2 ))}
+WORKERS=${WORKERS:-$(( $(nproc) - 2 ))}
 TMPFS_SIZE=${TMPFS_SIZE:-50g}
 export POLL=${POLL:-5}
 export TIMEOUT=${TIMEOUT:-1m}


### PR DESCRIPTION
Without this fix, bash doesn't correctly calculate the value of a variable

```
Building magma/afl/poppler
/bin/bash: -c: line 0: syntax error near unexpected token `('
/bin/bash: -c: line 0: `start_ex (( 8 - 2 )) 1 -1 start_campaign 0 afl libxml2 xmllint --valid --oldxml10 --push --memory @@ '
```